### PR TITLE
Shows location authorization sheet

### DIFF
--- a/Shared/Views/LocationManager.swift
+++ b/Shared/Views/LocationManager.swift
@@ -8,6 +8,9 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     override init() {
         super.init()
         locationManager.delegate = self
+    }
+    
+    func requestAuthorization() {
         locationManager.requestWhenInUseAuthorization()
     }
     

--- a/Shared/Views/MapView.swift
+++ b/Shared/Views/MapView.swift
@@ -109,7 +109,7 @@ struct MapView: View {
                 Text("We use your location to show nearby shuttles")
                     .font(.title2).bold()
                     .multilineTextAlignment(.center)
-                Text("Your location helps us center the map and calculate accurate ETAs for stops near you. We only access your location while you use the app.")
+                Text("We are going to ask for your location to show on the map. Your location helps us center the map and calculate accurate ETAs for stops near you.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -119,10 +119,12 @@ struct MapView: View {
                     hasSeenOnboarding = true
                     showOnboarding = false
                 }) {
-                    Text("Allow Location Access")
+                    Text("Continue")
                         .frame(maxWidth: .infinity)
+                        .padding()
                 }
                 .buttonStyle(.borderedProminent)
+                .cornerRadius(16)
                 Button("Not Now") {
                     hasSeenOnboarding = true
                     showOnboarding = false

--- a/Shared/Views/MapView.swift
+++ b/Shared/Views/MapView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 import MapKit
 
 struct MapView: View {
+    @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding: Bool = false
+    @State private var showOnboarding = false
+    
     @State private var showSheet = false
     @State private var region = MKCoordinateRegion(
         center: CLLocationCoordinate2D.RensselaerUnion,
@@ -89,6 +92,10 @@ struct MapView: View {
             fetchLocations()
             fetchRoutes()
             
+            if !hasSeenOnboarding {
+                showOnboarding = true
+            }
+            
             timer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { _ in
                 fetchLocations()
             }
@@ -96,6 +103,34 @@ struct MapView: View {
         .onDisappear {
             timer?.invalidate()
             timer = nil
+        }.sheet(isPresented: $showOnboarding) {
+            VStack(spacing: 16) {
+                Image(systemName: "location.circle.fill").font(.system(size: 56)).foregroundStyle(.tint)
+                Text("We use your location to show nearby shuttles")
+                    .font(.title2).bold()
+                    .multilineTextAlignment(.center)
+                Text("Your location helps us center the map and calculate accurate ETAs for stops near you. We only access your location while you use the app.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                Spacer()
+                Button(action: {
+                    locationManager.requestAuthorization()
+                    hasSeenOnboarding = true
+                    showOnboarding = false
+                }) {
+                    Text("Allow Location Access")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                Button("Not Now") {
+                    hasSeenOnboarding = true
+                    showOnboarding = false
+                }
+                .buttonStyle(.borderless)
+            }
+            .padding()
+            .presentationDetents([.medium, .large])
         }
     }
     

--- a/Shared/Views/MapView.swift
+++ b/Shared/Views/MapView.swift
@@ -18,8 +18,6 @@ struct MapView: View {
     var body: some View {
         ZStack {
             Map(position: .constant(.region(region))) {
-                UserAnnotation()
-                
                 // Add vehicle markers
                 ForEach(Array(vehicleLocations), id: \.key) { vehicleId, vehicle in
                     Marker(
@@ -82,6 +80,8 @@ struct MapView: View {
                         }
                     }
                 }
+                
+                UserAnnotation()
             }
             ScheduleAndETA()
         }


### PR DESCRIPTION
Implements an onboarding sheet to request location authorization from the user. This enhances the user experience by explaining why the app needs location access before prompting for permission.

The changes include:

- Adds a sheet that displays when the user first opens the app, explaining the need for location permissions.
- Implements logic to persist whether the user has seen the onboarding, using `AppStorage`.
- Requests location authorization only when the user interacts with the prompt.